### PR TITLE
Scaffold minimal task tracker MCP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+__pycache__/
+*.py[cod]
+*.egg-info/
+.venv/
+venv/
+dist/
+build/
+.pytest_cache/

--- a/index.html
+++ b/index.html
@@ -1,6 +1,0 @@
-<html>
-<h1> Making some changes here </h1>
-
-Thanks Github
-
-</html>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,18 @@
+[project]
+name = "task-tracker-mcp"
+version = "0.1.0"
+description = "Minimal MCP server for tracking tasks / todos."
+requires-python = ">=3.10"
+dependencies = [
+    "mcp>=1.2.0",
+]
+
+[project.scripts]
+task-tracker-mcp = "task_tracker_mcp.server:main"
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/task_tracker_mcp"]

--- a/src/task_tracker_mcp/__init__.py
+++ b/src/task_tracker_mcp/__init__.py
@@ -1,0 +1,3 @@
+from .server import main
+
+__all__ = ["main"]

--- a/src/task_tracker_mcp/server.py
+++ b/src/task_tracker_mcp/server.py
@@ -1,0 +1,63 @@
+import os
+from dataclasses import asdict
+from pathlib import Path
+
+from mcp.server.fastmcp import FastMCP
+
+from .storage import TaskStore
+
+DEFAULT_PATH = Path.home() / ".task-tracker" / "tasks.json"
+STORE_PATH = Path(os.environ.get("TASK_TRACKER_PATH", DEFAULT_PATH))
+
+mcp = FastMCP("task-tracker")
+store = TaskStore(STORE_PATH)
+
+
+@mcp.tool()
+def add_task(title: str, notes: str = "") -> dict:
+    """Create a new task. Returns the created task."""
+    return asdict(store.add(title=title, notes=notes))
+
+
+@mcp.tool()
+def list_tasks(status: str = "open") -> list[dict]:
+    """List tasks. status is one of: open (default), done, all."""
+    return [asdict(t) for t in store.list(status=status)]
+
+
+@mcp.tool()
+def complete_task(task_id: int) -> dict:
+    """Mark a task as done."""
+    return asdict(store.complete(task_id, done=True))
+
+
+@mcp.tool()
+def reopen_task(task_id: int) -> dict:
+    """Mark a previously completed task as open again."""
+    return asdict(store.complete(task_id, done=False))
+
+
+@mcp.tool()
+def update_task(task_id: int, title: str | None = None, notes: str | None = None) -> dict:
+    """Update a task's title and/or notes."""
+    return asdict(store.update(task_id, title=title, notes=notes))
+
+
+@mcp.tool()
+def delete_task(task_id: int) -> dict:
+    """Delete a task. Returns the deleted task."""
+    return asdict(store.delete(task_id))
+
+
+@mcp.tool()
+def clear_completed() -> dict:
+    """Remove all tasks marked done. Returns the number deleted."""
+    return {"removed": store.clear_done()}
+
+
+def main() -> None:
+    mcp.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/src/task_tracker_mcp/storage.py
+++ b/src/task_tracker_mcp/storage.py
@@ -1,0 +1,113 @@
+import json
+import os
+import threading
+from dataclasses import asdict, dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Iterable
+
+
+def _now() -> str:
+    return datetime.now(timezone.utc).isoformat(timespec="seconds")
+
+
+@dataclass
+class Task:
+    id: int
+    title: str
+    notes: str = ""
+    done: bool = False
+    created_at: str = field(default_factory=_now)
+    updated_at: str = field(default_factory=_now)
+    completed_at: str | None = None
+
+
+class TaskStore:
+    def __init__(self, path: Path):
+        self.path = path
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._lock = threading.Lock()
+
+    def _load(self) -> tuple[list[Task], int]:
+        if not self.path.exists():
+            return [], 1
+        raw = json.loads(self.path.read_text() or "{}")
+        tasks = [Task(**t) for t in raw.get("tasks", [])]
+        next_id = raw.get("next_id", max((t.id for t in tasks), default=0) + 1)
+        return tasks, next_id
+
+    def _save(self, tasks: list[Task], next_id: int) -> None:
+        payload = {"next_id": next_id, "tasks": [asdict(t) for t in tasks]}
+        tmp = self.path.with_suffix(self.path.suffix + ".tmp")
+        tmp.write_text(json.dumps(payload, indent=2))
+        os.replace(tmp, self.path)
+
+    def add(self, title: str, notes: str = "") -> Task:
+        with self._lock:
+            tasks, next_id = self._load()
+            task = Task(id=next_id, title=title, notes=notes)
+            tasks.append(task)
+            self._save(tasks, next_id + 1)
+            return task
+
+    def list(self, status: str = "open") -> list[Task]:
+        tasks, _ = self._load()
+        if status == "all":
+            return tasks
+        if status == "done":
+            return [t for t in tasks if t.done]
+        if status == "open":
+            return [t for t in tasks if not t.done]
+        raise ValueError(f"unknown status: {status!r} (expected open|done|all)")
+
+    def get(self, task_id: int) -> Task:
+        tasks, _ = self._load()
+        for t in tasks:
+            if t.id == task_id:
+                return t
+        raise KeyError(f"no task with id {task_id}")
+
+    def update(self, task_id: int, *, title: str | None = None, notes: str | None = None) -> Task:
+        with self._lock:
+            tasks, next_id = self._load()
+            task = _find(tasks, task_id)
+            if title is not None:
+                task.title = title
+            if notes is not None:
+                task.notes = notes
+            task.updated_at = _now()
+            self._save(tasks, next_id)
+            return task
+
+    def complete(self, task_id: int, done: bool = True) -> Task:
+        with self._lock:
+            tasks, next_id = self._load()
+            task = _find(tasks, task_id)
+            task.done = done
+            task.completed_at = _now() if done else None
+            task.updated_at = _now()
+            self._save(tasks, next_id)
+            return task
+
+    def delete(self, task_id: int) -> Task:
+        with self._lock:
+            tasks, next_id = self._load()
+            task = _find(tasks, task_id)
+            tasks = [t for t in tasks if t.id != task_id]
+            self._save(tasks, next_id)
+            return task
+
+    def clear_done(self) -> int:
+        with self._lock:
+            tasks, next_id = self._load()
+            remaining = [t for t in tasks if not t.done]
+            removed = len(tasks) - len(remaining)
+            self._save(remaining, next_id)
+            return removed
+
+
+def _find(tasks: Iterable[Task], task_id: int) -> Task:
+    for t in tasks:
+        if t.id == task_id:
+            return t
+    raise KeyError(f"no task with id {task_id}")

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import pytest
+
+from task_tracker_mcp.storage import TaskStore
+
+
+@pytest.fixture()
+def store(tmp_path: Path) -> TaskStore:
+    return TaskStore(tmp_path / "tasks.json")
+
+
+def test_add_then_list_open(store: TaskStore) -> None:
+    a = store.add("write tests")
+    b = store.add("ship it", notes="after review")
+    assert a.id == 1 and b.id == 2
+    assert [t.id for t in store.list()] == [1, 2]
+    assert b.notes == "after review"
+
+
+def test_complete_and_filter(store: TaskStore) -> None:
+    store.add("a")
+    store.add("b")
+    store.complete(1)
+    assert [t.id for t in store.list("open")] == [2]
+    assert [t.id for t in store.list("done")] == [1]
+    assert [t.id for t in store.list("all")] == [1, 2]
+
+
+def test_update_changes_fields(store: TaskStore) -> None:
+    store.add("old title", notes="old notes")
+    updated = store.update(1, title="new title")
+    assert updated.title == "new title"
+    assert updated.notes == "old notes"
+
+
+def test_delete_removes_task(store: TaskStore) -> None:
+    store.add("a")
+    store.add("b")
+    store.delete(1)
+    assert [t.id for t in store.list("all")] == [2]
+
+
+def test_clear_completed(store: TaskStore) -> None:
+    store.add("a")
+    store.add("b")
+    store.complete(1)
+    assert store.clear_done() == 1
+    assert [t.id for t in store.list("all")] == [2]
+
+
+def test_missing_task_raises(store: TaskStore) -> None:
+    with pytest.raises(KeyError):
+        store.complete(999)
+
+
+def test_persists_across_instances(tmp_path: Path) -> None:
+    path = tmp_path / "tasks.json"
+    TaskStore(path).add("survive restart")
+    reloaded = TaskStore(path).list("all")
+    assert [t.title for t in reloaded] == ["survive restart"]


### PR DESCRIPTION
JSON-backed TaskStore with add/list/complete/reopen/update/delete/clear tools exposed via FastMCP over stdio. Storage path overridable with TASK_TRACKER_PATH (defaults to ~/.task-tracker/tasks.json).

https://claude.ai/code/session_01EvqK8Ve1Nk7811wxHP31nA